### PR TITLE
Center sign-in button

### DIFF
--- a/routes/home.js
+++ b/routes/home.js
@@ -10,7 +10,7 @@ module.exports = () => {
           <h1>🩺 Vitals Tracker</h1>
           <p>Track your blood pressure and health metrics</p>
         </div>
-        <div class="form-container" style="text-align:center;">
+        <div class="form-container" style="display:flex;justify-content:center;">
           <a href="/vitals/auth/google" style="text-decoration:none;">
             <button type="button" style="display:flex;align-items:center;gap:12px;padding:14px 24px;background:linear-gradient(270deg,#ff4d4d,#ffcc00,#33cc33,#3399ff,#cc33cc);background-size:400% 400%;animation:rainbowShift 10s ease infinite;border:none;border-radius:12px;cursor:pointer;color:white;font-weight:600;font-size:16px;box-shadow:0 0 12px rgba(255,255,255,0.15);transition:transform 0.2s,box-shadow 0.3s;">
               <span style="background:white;border-radius:50%;width:24px;height:24px;display:grid;place-items:center;">


### PR DESCRIPTION
## Summary
- center the Google sign-in button on the home page

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_685caec5f92c833287e8c4791a814a6b