### PR TITLE
Escape user display name

### DIFF
--- a/views/renderPage.js
+++ b/views/renderPage.js
@@ -3,10 +3,19 @@ const path = require('path');
 
 const layoutTemplate = fs.readFileSync(path.join(__dirname, 'layout.html'), 'utf8');
 
+function escapeHtml(str) {
+    return String(str)
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#39;');
+}
+
 module.exports = function renderPage(content, user) {
     const isLoggedIn = !!user;
     const authLinks = isLoggedIn
-        ? `Welcome, ${user.displayName} | <a href="/vitals/logout">Log out</a>`
+        ? `Welcome, ${escapeHtml(user.displayName)} | <a href="/vitals/logout">Log out</a>`
         : `<a href="/vitals/auth/google">Log in with Google</a>`;
 
     return layoutTemplate


### PR DESCRIPTION
## Summary
- avoid XSS by escaping `user.displayName` before inserting it into HTML

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68801cc2414883328996d2ac3e00c396