### PR TITLE
Ignore vitals error log

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ stderr.log
 node_modules/
 .env
 tmp/
+vitals-error.log


### PR DESCRIPTION
## Summary
- ignore vitals-error.log in git

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68801cafda2883329f8f48f23cc9238a