### PR TITLE
Fix README heading formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
 You can start the app with `npm start`.
-=======
 # Vital Vitals
 
 A small Node.js application for recording blood pressure and other health metrics such as heart rate, temperature, weight and blood oxygen. It allows you to sign in with Google, log your vitals and export them as CSV for your doctor.


### PR DESCRIPTION
## Summary
- remove leftover separator line from README

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68801ca55af48332a84c1704d96b4353