### PR TITLE
Separate chart view and improve mobile layout

### DIFF
--- a/app.js
+++ b/app.js
@@ -37,6 +37,7 @@ const logoutRouter = require('./routes/logout')();
 const dashboardRouter = require('./routes/dashboard')();
 const saveRouter = require('./routes/save')(db);
 const myVitalsRouter = require('./routes/myVitals')(db);
+const chartRouter = require('./routes/chart')(db);
 const exportRouter = require('./routes/export')();
 const exportDownloadRouter = require('./routes/exportDownload')(db);
 
@@ -47,6 +48,7 @@ app.use('/vitals', logoutRouter);
 app.use('/vitals', dashboardRouter);
 app.use('/vitals', saveRouter);
 app.use('/vitals', myVitalsRouter);
+app.use('/vitals', chartRouter);
 app.use('/vitals', exportRouter);
 app.use('/vitals', exportDownloadRouter);
 

--- a/routes/chart.js
+++ b/routes/chart.js
@@ -1,0 +1,159 @@
+const express = require('express');
+const renderPage = require('../views/renderPage');
+
+module.exports = (db) => {
+  const router = express.Router();
+
+  router.get('/chart', async (req, res) => {
+    if (!req.user) return res.redirect('/vitals');
+
+    try {
+      const userId = req.user.id || req.user.emails?.[0]?.value;
+      const [results] = await db.query(
+        'SELECT * FROM vitals WHERE userId = ? AND date >= DATE_SUB(NOW(), INTERVAL 90 DAY) ORDER BY date DESC',
+        [userId]
+      );
+
+      const dates = [];
+      const heartRates = [];
+      const bloodPressures = [];
+      const temperatures = [];
+      const weights = [];
+      const bloodOxygens = [];
+
+      results.forEach(row => {
+        const d = new Date(row.date);
+        const mm = String(d.getMonth() + 1).padStart(2, '0');
+        const dd = String(d.getDate()).padStart(2, '0');
+        const yyyy = d.getFullYear();
+        let hours = d.getHours();
+        const minutes = String(d.getMinutes()).padStart(2, '0');
+        const ampm = hours >= 12 ? 'PM' : 'AM';
+        hours = hours % 12;
+        hours = hours ? hours : 12;
+        const formattedDate = `${mm}/${dd}/${yyyy}`;
+        const formattedTime = `${hours}:${minutes} ${ampm}`;
+        dates.push(`${formattedDate} ${formattedTime}`);
+        heartRates.push(row.heart_rate);
+        bloodPressures.push(row.blood_pressure);
+        temperatures.push(row.temperature);
+        weights.push(row.weight_lbs);
+        bloodOxygens.push(row.blood_oxygen);
+      });
+
+      const chartScript = `
+        <script>
+          const chartLabels = ${JSON.stringify(dates)};
+          const heartRates = ${JSON.stringify(heartRates)};
+          const temperatures = ${JSON.stringify(temperatures)};
+          const weights = ${JSON.stringify(weights)};
+          const bloodPressures = ${JSON.stringify(bloodPressures)};
+          const bloodOxygens = ${JSON.stringify(bloodOxygens)};
+          const systolic = bloodPressures.map(bp => parseInt((bp||'').split('/')[0]) || null);
+          const diastolic = bloodPressures.map(bp => parseInt((bp||'').split('/')[1]) || null);
+
+          const ctx = document.getElementById('vitalsChart').getContext('2d');
+          new Chart(ctx, {
+            type: 'line',
+            data: {
+              labels: chartLabels,
+              datasets: [
+                {
+                  label: 'Heart Rate (bpm)',
+                  data: heartRates,
+                  borderColor: '#ff6b81',
+                  backgroundColor: 'rgba(255, 107, 129, 0.2)',
+                  yAxisID: 'y',
+                  spanGaps: true,
+                  tension: 0.4
+                },
+                {
+                  label: 'Temperature (°F)',
+                  data: temperatures,
+                  borderColor: '#4bc0c0',
+                  backgroundColor: 'rgba(75, 192, 192, 0.2)',
+                  yAxisID: 'y1',
+                  spanGaps: true,
+                  tension: 0.4
+                },
+                {
+                  label: 'Weight (lbs)',
+                  data: weights,
+                  borderColor: '#ffcd56',
+                  backgroundColor: 'rgba(255, 205, 86, 0.2)',
+                  yAxisID: 'y2',
+                  spanGaps: true,
+                  tension: 0.4
+                },
+                {
+                  label: 'Systolic BP',
+                  data: systolic,
+                  borderColor: '#6c5ce7',
+                  backgroundColor: 'rgba(108, 92, 231, 0.2)',
+                  yAxisID: 'y3',
+                  spanGaps: true,
+                  tension: 0.4
+                },
+                {
+                  label: 'Diastolic BP',
+                  data: diastolic,
+                  borderColor: '#a29bfe',
+                  backgroundColor: 'rgba(162, 155, 254, 0.2)',
+                  yAxisID: 'y3',
+                  spanGaps: true,
+                  tension: 0.4
+                },
+                {
+                  label: 'O₂ Saturation (%)',
+                  data: bloodOxygens,
+                  borderColor: '#00b894',
+                  backgroundColor: 'rgba(0, 184, 148, 0.2)',
+                  yAxisID: 'y4',
+                  spanGaps: true,
+                  tension: 0.4
+                }
+              ]
+            },
+            options: {
+              responsive: true,
+              interaction: { mode: 'index', intersect: false },
+              stacked: false,
+              plugins: { legend: { position: 'top' } },
+              scales: {
+                y: { type: 'linear', display: true, position: 'left', title: { display: true, text: 'Heart Rate' } },
+                y1: { type: 'linear', display: true, position: 'right', title: { display: true, text: 'Temperature' }, grid: { drawOnChartArea: false } },
+                y2: { type: 'linear', display: true, position: 'right', title: { display: true, text: 'Weight' }, grid: { drawOnChartArea: false }, offset: true },
+                y3: { type: 'linear', display: true, position: 'right', title: { display: true, text: 'Blood Pressure' }, grid: { drawOnChartArea: false }, offset: true },
+                y4: { type: 'linear', display: true, position: 'right', title: { display: true, text: 'O₂ Saturation' }, grid: { drawOnChartArea: false }, offset: true }
+              }
+            }
+          });
+        </script>
+      `;
+
+      const content = `
+        <div class="container">
+          <div class="header">
+            <h1>📈 Vitals Chart</h1>
+            <p>Visualize your vitals over the last 3 months.</p>
+            <a href="/vitals/my-vitals" class="chart-link">Back to Entries</a>
+          </div>
+          <div class="card">
+            <div class="card-body">
+              <canvas id="vitalsChart" height="150"></canvas>
+            </div>
+          </div>
+        </div>
+        ${chartScript}
+      `;
+
+      res.send(renderPage(content, req.user));
+    } catch (err) {
+      console.error('❌ Failed to load chart:', err);
+      res.send('Error loading chart');
+    }
+  });
+
+  return router;
+};
+

--- a/routes/myVitals.js
+++ b/routes/myVitals.js
@@ -8,39 +8,11 @@ module.exports = (db) => {
 
     try {
       const userId = req.user.id || req.user.emails?.[0]?.value;
-      // Fetch only the last 30 days of records for the logged in user
+      // Fetch the last 3 months of records for the logged in user
       const [results] = await db.query(
-        'SELECT * FROM vitals WHERE userId = ? AND date >= DATE_SUB(NOW(), INTERVAL 30 DAY) ORDER BY date DESC',
+        'SELECT * FROM vitals WHERE userId = ? AND date >= DATE_SUB(NOW(), INTERVAL 90 DAY) ORDER BY date DESC',
         [userId]
       );
-
-      const chartResults = results.slice(0, 25);
-      const dates = [];
-      const heartRates = [];
-      const bloodPressures = [];
-      const temperatures = [];
-      const weights = [];
-      const bloodOxygens = [];
-
-      chartResults.forEach(row => {
-        const d = new Date(row.date);
-        const mm = String(d.getMonth() + 1).padStart(2, '0');
-        const dd = String(d.getDate()).padStart(2, '0');
-        const yyyy = d.getFullYear();
-        let hours = d.getHours();
-        const minutes = String(d.getMinutes()).padStart(2, '0');
-        const ampm = hours >= 12 ? 'PM' : 'AM';
-        hours = hours % 12;
-        hours = hours ? hours : 12;
-        const formattedDate = `${mm}/${dd}/${yyyy}`;
-        const formattedTime = `${hours}:${minutes} ${ampm}`;
-        dates.push(`${formattedDate} ${formattedTime}`);
-        heartRates.push(row.heart_rate);
-        bloodPressures.push(row.blood_pressure);
-        temperatures.push(row.temperature);
-        weights.push(row.weight_lbs);
-        bloodOxygens.push(row.blood_oxygen);
-      });
 
       let tableBody = '';
       if (results.length === 0) {
@@ -61,132 +33,33 @@ module.exports = (db) => {
           const weightKg = (row.weight_lbs * 0.453592).toFixed(1);
           return `
             <tr>
-              <td>
+              <td data-label="Date">
                 ${formattedDate}<br>
                 <span style="font-size: 0.85em; color: #666;">${formattedTime}</span>
               </td>
-              <td>${row.heart_rate}</td>
-              <td>${row.blood_pressure}</td>
-              <td>${row.temperature}</td>
-              <td>
+              <td data-label="Heart Rate">${row.heart_rate}</td>
+              <td data-label="Blood Pressure">${row.blood_pressure}</td>
+              <td data-label="Temperature">${row.temperature}</td>
+              <td data-label="Weight">
                 ${row.weight_lbs} lbs<br>
                 <span style="font-size: 0.85em; color: #666;">(${weightKg} kg)</span>
               </td>
-              <td title="O₂ Saturation">${row.blood_oxygen ?? ''}</td>
+              <td data-label="O₂ Saturation" title="O₂ Saturation">${row.blood_oxygen ?? ''}</td>
             </tr>
           `;
         }).join('');
       }
-
-      const chartScript = `
-        <script>
-          const chartLabels = ${JSON.stringify(dates)};
-          const heartRates = ${JSON.stringify(heartRates)};
-          const temperatures = ${JSON.stringify(temperatures)};
-          const weights = ${JSON.stringify(weights)};
-          const bloodPressures = ${JSON.stringify(bloodPressures)};
-          const bloodOxygens = ${JSON.stringify(bloodOxygens)};
-          const systolic = bloodPressures.map(bp => parseInt((bp||'').split('/')[0]) || null);
-          const diastolic = bloodPressures.map(bp => parseInt((bp||'').split('/')[1]) || null);
-
-          const ctx = document.getElementById('vitalsChart').getContext('2d');
-          new Chart(ctx, {
-            type: 'line',
-            data: {
-              labels: chartLabels,
-              datasets: [
-                {
-                  label: 'Heart Rate (bpm)',
-                  data: heartRates,
-                  borderColor: '#ff6b81',
-                  backgroundColor: 'rgba(255, 107, 129, 0.2)',
-                  yAxisID: 'y',
-                  spanGaps: true,
-                  tension: 0.4
-                },
-                {
-                  label: 'Temperature (°F)',
-                  data: temperatures,
-                  borderColor: '#4bc0c0',
-                  backgroundColor: 'rgba(75, 192, 192, 0.2)',
-                  yAxisID: 'y1',
-                  spanGaps: true,
-                  tension: 0.4
-                },
-                {
-                  label: 'Weight (lbs)',
-                  data: weights,
-                  borderColor: '#ffcd56',
-                  backgroundColor: 'rgba(255, 205, 86, 0.2)',
-                  yAxisID: 'y2',
-                  spanGaps: true,
-                  tension: 0.4
-                },
-                {
-                  label: 'Systolic BP',
-                  data: systolic,
-                  borderColor: '#6c5ce7',
-                  backgroundColor: 'rgba(108, 92, 231, 0.2)',
-                  yAxisID: 'y3',
-                  spanGaps: true,
-                  tension: 0.4
-                },
-                {
-                  label: 'Diastolic BP',
-                  data: diastolic,
-                  borderColor: '#a29bfe',
-                  backgroundColor: 'rgba(162, 155, 254, 0.2)',
-                  yAxisID: 'y3',
-                  spanGaps: true,
-                  tension: 0.4
-                },
-                {
-                  label: 'O₂ Saturation (%)',
-                  data: bloodOxygens,
-                  borderColor: '#00b894',
-                  backgroundColor: 'rgba(0, 184, 148, 0.2)',
-                  yAxisID: 'y4',
-                  spanGaps: true,
-                  tension: 0.4
-                }
-              ]
-            },
-            options: {
-              responsive: true,
-              interaction: { mode: 'index', intersect: false },
-              stacked: false,
-              plugins: { legend: { position: 'top' } },
-              scales: {
-                y: { type: 'linear', display: true, position: 'left', title: { display: true, text: 'Heart Rate' } },
-                y1: { type: 'linear', display: true, position: 'right', title: { display: true, text: 'Temperature' }, grid: { drawOnChartArea: false } },
-                y2: { type: 'linear', display: true, position: 'right', title: { display: true, text: 'Weight' }, grid: { drawOnChartArea: false }, offset: true },
-                y3: { type: 'linear', display: true, position: 'right', title: { display: true, text: 'Blood Pressure' }, grid: { drawOnChartArea: false }, offset: true },
-                y4: { type: 'linear', display: true, position: 'right', title: { display: true, text: 'O₂ Saturation' }, grid: { drawOnChartArea: false }, offset: true }
-              }
-            }
-          });
-        </script>
-      `;
 
       const content = `
         <div class="container">
           <div class="header">
             <h1>📊 Your Vitals</h1>
             <p>Review your previously logged health entries.</p>
+            <a href="/vitals/chart" class="chart-link">View Chart</a>
             <a href="/vitals/export" title="Export to CSV/Excel" class="export-link">
               <span role="img" aria-label="Export">📄</span>
             </a>
           </div>
-
-          <div class="card">
-            <div class="card-header">
-              <h2>Vitals Chart</h2>
-            </div>
-            <div class="card-body">
-              <canvas id="vitalsChart" height="150"></canvas>
-            </div>
-          </div>
-
           <div class="card">
             <div class="card-header">
               <h2>Recent Entries</h2>
@@ -212,7 +85,6 @@ module.exports = (db) => {
             </div>
           </div>
         </div>
-        ${chartScript}
       `;
 
       res.send(renderPage(content, req.user));

--- a/views/layout.html
+++ b/views/layout.html
@@ -65,7 +65,8 @@
       color: #eee;
     }
 
-    .export-link {
+    .export-link,
+    .chart-link {
       display: inline-block;
       margin-top: 10px;
       font-size: 1.2em;
@@ -77,7 +78,8 @@
       transition: background-color 0.3s ease;
     }
 
-    .export-link:hover {
+    .export-link:hover,
+    .chart-link:hover {
       background-color: rgba(255, 255, 255, 0.3);
     }
 
@@ -209,6 +211,36 @@
       padding: 50px 0;
     }
 
+    @media (max-width: 600px) {
+      .vitals-table thead {
+        display: none;
+      }
+      .vitals-table,
+      .vitals-table tbody,
+      .vitals-table tr,
+      .vitals-table td {
+        display: block;
+        width: 100%;
+      }
+      .vitals-table tr {
+        margin-bottom: 15px;
+      }
+      .vitals-table td {
+        text-align: right;
+        padding-left: 50%;
+        position: relative;
+      }
+      .vitals-table td::before {
+        content: attr(data-label);
+        position: absolute;
+        left: 0;
+        width: 45%;
+        padding-left: 15px;
+        font-weight: bold;
+        text-align: left;
+      }
+    }
+
     @media (max-width: 480px) {
       .form-row {
         flex-direction: column;
@@ -298,8 +330,6 @@
   
 
   {{content}}
-
-  <canvas id="vitalsChart" height="120"></canvas>
 
 <script>
   document.addEventListener("DOMContentLoaded", function () {


### PR DESCRIPTION
## Summary
- show last three months of vitals in the entries view
- move charting to a dedicated `/chart` page and link to it from entries
- add responsive table styles for better phone display

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_689e23d947248332b2077188a66e7e07