### PR TITLE
Add highest/lowest values to Your Vitals summary periods

### DIFF
--- a/routes/myVitals.js
+++ b/routes/myVitals.js
@@ -18,18 +18,36 @@ function average(values) {
   return (validValues.reduce((sum, value) => sum + value, 0) / validValues.length).toFixed(1);
 }
 
+function highest(values) {
+  const validValues = values.filter(value => typeof value === 'number' && !Number.isNaN(value));
+  if (validValues.length === 0) return '—';
+  return Math.max(...validValues).toFixed(1);
+}
+
+function lowest(values) {
+  const validValues = values.filter(value => typeof value === 'number' && !Number.isNaN(value));
+  if (validValues.length === 0) return '—';
+  return Math.min(...validValues).toFixed(1);
+}
+
+function metricSummary(values, unit) {
+  return `${average(values)}${unit} (H: ${highest(values)}${unit}, L: ${lowest(values)}${unit})`;
+}
+
 function buildAverageCard(label, records) {
   const parsedPressures = records.map(row => parseBloodPressure(row.blood_pressure));
+  const systolicValues = parsedPressures.map(bp => bp.systolic);
+  const diastolicValues = parsedPressures.map(bp => bp.diastolic);
 
   return `
     <div class="avg-card">
       <h3>${label}</h3>
       <ul>
-        <li><strong>Heart Rate:</strong> ${average(records.map(row => Number(row.heart_rate)))} bpm</li>
-        <li><strong>Blood Pressure:</strong> ${average(parsedPressures.map(bp => bp.systolic))}/${average(parsedPressures.map(bp => bp.diastolic))}</li>
-        <li><strong>Temperature:</strong> ${average(records.map(row => Number(row.temperature)))} °F</li>
-        <li><strong>Weight:</strong> ${average(records.map(row => Number(row.weight_lbs)))} lbs</li>
-        <li><strong>O₂ Saturation:</strong> ${average(records.map(row => Number(row.blood_oxygen)))}%</li>
+        <li><strong>Heart Rate:</strong> ${metricSummary(records.map(row => Number(row.heart_rate)), ' bpm')}</li>
+        <li><strong>Blood Pressure:</strong> ${average(systolicValues)}/${average(diastolicValues)} (H: ${highest(systolicValues)}/${highest(diastolicValues)}, L: ${lowest(systolicValues)}/${lowest(diastolicValues)})</li>
+        <li><strong>Temperature:</strong> ${metricSummary(records.map(row => Number(row.temperature)), ' °F')}</li>
+        <li><strong>Weight:</strong> ${metricSummary(records.map(row => Number(row.weight_lbs)), ' lbs')}</li>
+        <li><strong>O₂ Saturation:</strong> ${metricSummary(records.map(row => Number(row.blood_oxygen)), '%')}</li>
       </ul>
     </div>
   `;


### PR DESCRIPTION
### Motivation
- Provide richer summary statistics on the “Your Vitals” page so each summary card shows not only the average but also the highest and lowest values for the selected period (Last 5 entries, 7 day, 30 day).
- Make high/low formatting consistent and reusable across metrics including heart rate, blood pressure, temperature, weight, and O₂ saturation.

### Description
- Added helper functions `highest`, `lowest`, and `metricSummary` and integrated them into the summary renderer to produce "Average (H: highest, L: lowest)" formatting in `routes/myVitals.js`.
- Extended `buildAverageCard` to compute `systolicValues` and `diastolicValues` from parsed blood pressure and display average plus high/low for both systolic and diastolic pressures.
- Updated heart rate, temperature, weight, and O₂ saturation displays to use `metricSummary` for consistent average/high/low output.
- Changes are contained in `routes/myVitals.js` where the summary card HTML is generated.

### Testing
- Ran `node --check routes/myVitals.js` which succeeded with no syntax errors.
- Ran `npm start` to exercise the app, which failed to fully boot due to missing OAuth `clientID` configuration in this environment, so full runtime UI validation could not be completed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699226764f988332937437f32454c4cf)